### PR TITLE
select runner from group

### DIFF
--- a/.github/workflows/github-actions-ec2.yml
+++ b/.github/workflows/github-actions-ec2.yml
@@ -5,7 +5,9 @@ on:
       - main
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on:
+      group: EC2
+      labels: [self-hosted, deploy]
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2


### PR DESCRIPTION
Created a new runner group called `EC2`, and added a new runner named `shared` and labeled `deploy`

This should hopefully switch to the new runner