### PR TITLE
Added interview pool time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ backend/.vscode/*
 *.log
 *.log.*
 *django.log*
+.DS_Store

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "axios": "^1.6.7",
+        "axios": "^1.7.9",
         "jwt-decode": "^4.0.0",
         "react": "^18.2.0",
         "react-copy-to-clipboard": "^5.1.0",
@@ -1466,11 +1466,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -2337,9 +2337,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "axios": "^1.6.7",
+    "axios": "^1.7.9",
     "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-copy-to-clipboard": "^5.1.0",

--- a/server/interview/views.py
+++ b/server/interview/views.py
@@ -78,13 +78,10 @@ def get_next_cutoff(user_timezone="America/Los_Angeles", force_current_week=Fals
         days_since_sunday = current_time.weekday() + 1
         last_sunday = current_time - timezone.timedelta(days=days_since_sunday)
         last_sunday = last_sunday.replace(hour=23, minute=0, second=0, microsecond=0)
-
-        logger.info(f"Last Sunday: {last_sunday}")
         
         # By default, return the previous Sunday
         # If force_current_week, return next Sunday
         if force_current_week == "true":
-            logger.info("Force current week")
             return last_sunday + timezone.timedelta(days=7)  # One week ahead
         return last_sunday  # Most recent Sunday
 
@@ -117,7 +114,6 @@ class GetSignupData(APIView):
         # start_date = end_date - timedelta(days=days)
         next_cutoff = get_next_cutoff()
         previous_cutoff = get_previous_cutoff(days)
-        logger.info(f"Next cutoff: {next_cutoff}, previous cutoff: {previous_cutoff}")
 
         signups = InterviewPool.objects.filter(
             timestamp__isnull=False, timestamp__gte=previous_cutoff, timestamp__lte=next_cutoff
@@ -235,7 +231,6 @@ class GetInterviewPoolStatus(APIView):
             next_cutoff = get_next_cutoff(force_current_week=force_current_week)
             previous_cutoff = get_previous_cutoff(force_current_week=force_current_week)
             interview_pool = InterviewPool.objects.filter(timestamp__gte=previous_cutoff, timestamp__lte=next_cutoff)
-            logger.info(f"Next cutoff: {next_cutoff}, previous cutoff: {previous_cutoff}, force_current_week: {force_current_week}")
 
             logger.info(
                 "Interview pool status: %d members signed up", len(interview_pool)
@@ -265,7 +260,8 @@ class PairInterview(APIView):
         force_current_week = request.data.get('force_current_week', False)
         next_cutoff = get_next_cutoff(force_current_week=force_current_week)
         previous_cutoff = get_previous_cutoff(force_current_week=force_current_week)
-        logger.info(f"Next cutoff: {next_cutoff}, previous cutoff: {previous_cutoff} force_current_week: {force_current_week}")
+
+        logger.info(f"Next cutoff: {next_cutoff}, previous cutoff: {previous_cutoff}, force_current_week: {force_current_week}")
 
         if next_cutoff is None or previous_cutoff is None:
             return Response(

--- a/server/interview/views.py
+++ b/server/interview/views.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 from django.utils import timezone
+from django.utils.timezone import now as django_now
 import random
 from rest_framework import generics, status, permissions
 from rest_framework.permissions import IsAuthenticated
@@ -70,11 +72,14 @@ class GetSignupData(APIView):
 
     def get(self, request):
         days = int(request.query_params.get("days", 14))
-        end_date = timezone.now()
-        start_date = end_date - timedelta(days=days)
+        # end_date = timezone.now()
+        # start_date = end_date - timedelta(days=days)
+        next_cutoff = PairInterview.get_next_cutoff()
+        previous_cutoff = PairInterview.get_previous_cutoff(days)
+        logger.info(f"Next cutoff: {next_cutoff}, previous cutoff: {previous_cutoff}")
 
         signups = InterviewPool.objects.filter(
-            timestamp__isnull=False, timestamp__gte=start_date, timestamp__lte=end_date
+            timestamp__isnull=False, timestamp__gte=previous_cutoff, timestamp__lte=next_cutoff
         ).values("member__username", "member_id", "timestamp")
 
         signup_data = [
@@ -185,7 +190,10 @@ class GetInterviewPoolStatus(APIView):
 
     def get(self, request):
         try:
-            interview_pool = InterviewPool.objects.all()
+            next_cutoff = PairInterview.get_next_cutoff()
+            previous_cutoff = PairInterview.get_previous_cutoff(days=7) 
+            interview_pool = InterviewPool.objects.filter(timestamp__gte=previous_cutoff, timestamp__lte=next_cutoff)
+
             logger.info(
                 "Interview pool status: %d members signed up", len(interview_pool)
             )
@@ -193,6 +201,8 @@ class GetInterviewPoolStatus(APIView):
                 {
                     "number_sign_up": len(interview_pool),
                     "members": [member.member.username for member in interview_pool],
+                    "next_cutoff": next_cutoff.isoformat(),
+                    "previous_cutoff": previous_cutoff.isoformat(),
                 }
             )
         except InterviewPool.DoesNotExist:
@@ -207,10 +217,52 @@ class PairInterview(APIView):
         super().__init__(*args, **kwargs)
         self.pairing_algorithm = CommonAvailabilityStableMatching()
 
+    def get_next_cutoff(user_timezone="America/Los_Angeles"):
+        """Get the next Sunday at 11 PM in the specified timezone"""
+        # yeah this is definitely not cursed_time p2
+        try:
+            current_time = django_now().astimezone(ZoneInfo(user_timezone))
+        except Exception as e:
+            logger.error(f"Error getting current time in {user_timezone}: {e}")
+            return None
+
+        # get the next Sunday at 11 PM
+        days_until_sunday = (6 - current_time.weekday()) % 7
+        if days_until_sunday == 0 and current_time.hour >= 23:
+            days_until_sunday = 7
+        
+        next_sunday = current_time + timezone.timedelta(days=days_until_sunday)
+        try:
+            next_sunday = next_sunday.replace(hour=23, minute=0, second=0, microsecond=0)
+        except Exception as e:
+            # no sunday exists somehow
+            logger.error(f"No sunday exists in {user_timezone}")
+            return None
+        return next_sunday
+    
+    def get_previous_cutoff(days: int = 7, user_timezone="America/Los_Angeles"):
+        """Get the Sunday days before at 11 PM in the specified timezone"""
+        next_sunday = PairInterview.get_next_cutoff(user_timezone)
+        if next_sunday:
+            return next_sunday - timezone.timedelta(days=days)
+        return None
+
+
     @transaction.atomic
     def post(self, request):
-        pool_members = list(InterviewPool.objects.all())
+        next_cutoff = self.get_next_cutoff()
+        previous_cutoff = self.get_previous_cutoff(days=7)
+        logger.info(f"Next cutoff: {next_cutoff}, previous cutoff: {previous_cutoff}")
 
+        if next_cutoff is None or previous_cutoff is None:
+            return Response(
+                {"detail": "Error getting cutoff time."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        
+        next_week_cutoff = next_cutoff + timezone.timedelta(days=7)
+        pool_members = InterviewPool.objects.filter(timestamp__gte=next_week_cutoff, timestamp__lte=next_week_cutoff)
+        
         if len(pool_members) % 2 != 0:
             random_idx_of_death = random.randint(0, len(pool_members) - 1)
             rip = pool_members.pop(random_idx_of_death)


### PR DESCRIPTION
- By default, pairing will run for signups before 11 pm on the most recent Sunday in Pacific Time
- These will be 7 days before, e.g. from 11 pm on the previous Sunday to 10:59:59 pm on this past sunday
- There is an option to force_current week, which takes all signups from 11 pm on this past Sunday and to the upcoming Sunday