### PR TITLE
add user stats

### DIFF
--- a/server/engagement/urls.py
+++ b/server/engagement/urls.py
@@ -58,4 +58,9 @@ urlpatterns = [
         view=views.UpdateDailyChecksView.as_view(),
         name="cohort-update-daily-check",
     ),
+    path(
+        "user/<int:id>/",
+        views.GetUserStats.as_view(),
+        name="get-user-stats",
+    )
 ]

--- a/server/engagement/views.py
+++ b/server/engagement/views.py
@@ -20,6 +20,8 @@ from .serializers import AttendanceSessionSerializer, MemberSerializer
 from django.db import transaction
 from django.http import JsonResponse
 from .models import CohortStats
+from leaderboard.models import LeetcodeStats, GitHubStats
+from leaderboard.serializers import LeetcodeStatsSerializer, GitHubStatsSerializer
 from .serializers import CohortStatsSerializer
 from cohort.models import Cohort
 
@@ -207,6 +209,24 @@ class InjestMessageEventView(generics.CreateAPIView):
                 {"error": "internal server error"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
+
+
+class GetUserStats(APIView):
+    permission_classes = [IsVerified | IsApiKey]
+
+    def get(self, request, id):
+        user = request.user if not id else get_object_or_404(User, id=id)
+
+        return Response(
+            {
+                "leetcode": LeetcodeStatsSerializer(
+                    LeetcodeStats.objects.get(user=user)
+                ).data,
+                "github": GitHubStatsSerializer(
+                    GitHubStats.objects.get(user=user)
+                ).data,
+            }
+        )
 
 
 class QueryDiscordMessageStats(generics.ListAPIView):


### PR DESCRIPTION
Add endpoint for individual stats. For now just github and leetcode since it's the only use case we have, but can add additional as needed.

Related:
- https://github.com/swecc-uw/swecc-interview/pull/106
- https://github.com/swecc-uw/swecc-engagement/pull/26
- https://github.com/swecc-uw/swecc-leaderboard/pull/22